### PR TITLE
grammar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 There is a tool for storing passwords.
 
-There are a Curses interface and an API.
+There has a Curses interface and an API.
 
 # General usage
 


### PR DESCRIPTION
"There are an" isn't grammatically correct if followed by "curses interface". It should be either "There are a Curses interface" (if describing what There has, or "There has a Curses interface" if describing attributes of the program.
